### PR TITLE
change format from json to hex

### DIFF
--- a/src/evmManager.ts
+++ b/src/evmManager.ts
@@ -64,7 +64,7 @@ export const evmManager = new Elysia({ prefix: '/evm' })
             fees: "0",
             gas: "0",
             memo: "",
-            format: "json",
+            format: "hex",
             tokenId: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
             validatorAddress: "",
             params: {


### PR DESCRIPTION
Change format from json to hex, it's an easier payload to deal with when signing transaction with ethers.js !